### PR TITLE
don't print ls output when calling help command

### DIFF
--- a/comm.ands
+++ b/comm.ands
@@ -13,5 +13,6 @@ help:
 		jmp powerush		
 
 helpout: db 10,13,"l - LS",10,13,"c - exit (sorta)",10,13
+empty_helpout: db 0
 lsout: db 10,13,"Empty",10,13
 empty: db 0


### PR DESCRIPTION
idk why this works but it does